### PR TITLE
Ease Store interactions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,7 +113,7 @@ GEM
     emoji_regex (1.0.1)
     escape (0.0.4)
     excon (0.71.1)
-    faraday (0.17.1)
+    faraday (0.17.3)
       multipart-post (>= 1.2, < 3)
     faraday-cookie_jar (0.0.6)
       faraday (>= 0.7.4)

--- a/Sources/Mini/Promise.swift
+++ b/Sources/Mini/Promise.swift
@@ -254,4 +254,18 @@ extension Promise where T: Equatable {
         }
         return true
     }
+
+    public static func != (lhs: Promise<T>, rhs: Promise<T>) -> Bool {
+        !(lhs == rhs)
+    }
+}
+
+public func == <T: Equatable>(lhs: [Promise<T>], rhs: [Promise<T>]) -> Bool {
+    guard lhs.count == rhs.count else { return false }
+    for (left, right) in zip(lhs, rhs) {
+        if left != right {
+            return false
+        }
+    }
+    return true
 }

--- a/Sources/Mini/Store.swift
+++ b/Sources/Mini/Store.swift
@@ -130,3 +130,17 @@ public extension Store {
         startWith(state)
     }
 }
+
+extension Store {
+    public func dispatch<A: Action>(_ action: @autoclosure @escaping () -> A) -> Observable<Store.State> {
+        let action = action()
+        dispatcher.dispatch(action, mode: .sync)
+        return objectWillChange.asObservable()
+    }
+}
+
+extension ObservableType where Element: StateType {
+    public func withStateChanges<T>(in stateComponent: @escaping @autoclosure () -> KeyPath<Element, T>) -> Observable<T> {
+        return map(stateComponent()).skip(1)
+    }
+}

--- a/Sources/Mini/Store.swift
+++ b/Sources/Mini/Store.swift
@@ -137,10 +137,24 @@ extension Store {
         dispatcher.dispatch(action, mode: .sync)
         return objectWillChange.asObservable()
     }
+
+    public func withStateChanges<T>(in stateComponent: @escaping @autoclosure () -> KeyPath<Element, T>, that componentProperty: @escaping @autoclosure () -> KeyPath<T, Bool>) -> Observable<T> {
+        map(stateComponent()).filter(componentProperty())
+    }
 }
 
 extension ObservableType where Element: StateType {
+    /**
+     Maps from a `StateType` property to create an `Observable` that contains the filtered property and all its changes.
+     */
     public func withStateChanges<T>(in stateComponent: @escaping @autoclosure () -> KeyPath<Element, T>, that componentProperty: @escaping @autoclosure () -> KeyPath<T, Bool>) -> Observable<T> {
-        return map(stateComponent()).filter(one: componentProperty())
+        return map(stateComponent()).filter(componentProperty())
+    }
+
+    /**
+     Maps from a `StateType` property to create an `Observable` that contains the filtered property and all its changes.
+     */
+    public func withStateChanges<T: PromiseType>(in stateComponent: @escaping @autoclosure () -> KeyPath<Element, T>) -> Observable<T> {
+        return map(stateComponent()).filter(\.isFulfilled)
     }
 }

--- a/Sources/Mini/Store.swift
+++ b/Sources/Mini/Store.swift
@@ -140,7 +140,7 @@ extension Store {
 }
 
 extension ObservableType where Element: StateType {
-    public func withStateChanges<T>(in stateComponent: @escaping @autoclosure () -> KeyPath<Element, T>) -> Observable<T> {
-        return map(stateComponent()).skip(1)
+    public func withStateChanges<T>(in stateComponent: @escaping @autoclosure () -> KeyPath<Element, T>, that componentProperty: @escaping @autoclosure () -> KeyPath<T, Bool>) -> Observable<T> {
+        return map(stateComponent()).filter(one: componentProperty())
     }
 }

--- a/Sources/Mini/Utils/RxSwift/ObservableType+Extensions.swift
+++ b/Sources/Mini/Utils/RxSwift/ObservableType+Extensions.swift
@@ -32,21 +32,21 @@ extension ObservableType {
     /// - Parameter fn: Filter closure.
     /// - Returns: The first element that matches the filter.
     public func filterOne(_ condition: @escaping (Element) -> Bool) -> Observable<Element> {
-        return filter {
+        filter {
             condition($0)
         }.take(1)
     }
 
-    public func filter(one condition: KeyPath<Element, Bool>) -> Observable<Element> {
-        filter(condition).take(1)
-    }
-
     public func filter(_ keyPath: KeyPath<Element, Bool>) -> Observable<Element> {
-        return filter { $0[keyPath: keyPath] }
+        filter { $0[keyPath: keyPath] }
     }
 
     public func map<T>(_ keyPath: KeyPath<Element, T>) -> Observable<T> {
-        return map { $0[keyPath: keyPath] }
+        map { $0[keyPath: keyPath] }
+    }
+
+    public func one() -> Observable<Element> {
+        take(1)
     }
 }
 

--- a/Sources/Mini/Utils/RxSwift/ObservableType+Extensions.swift
+++ b/Sources/Mini/Utils/RxSwift/ObservableType+Extensions.swift
@@ -37,6 +37,10 @@ extension ObservableType {
         }.take(1)
     }
 
+    public func filter(one condition: KeyPath<Element, Bool>) -> Observable<Element> {
+        filter(condition).take(1)
+    }
+
     public func filter(_ keyPath: KeyPath<Element, Bool>) -> Observable<Element> {
         return filter { $0[keyPath: keyPath] }
     }

--- a/Sources/Mini/Utils/RxSwift/ObservableType+Extensions.swift
+++ b/Sources/Mini/Utils/RxSwift/ObservableType+Extensions.swift
@@ -36,6 +36,14 @@ extension ObservableType {
             condition($0)
         }.take(1)
     }
+
+    public func filter(_ keyPath: KeyPath<Element, Bool>) -> Observable<Element> {
+        return filter { $0[keyPath: keyPath] }
+    }
+
+    public func map<T>(_ keyPath: KeyPath<Element, T>) -> Observable<T> {
+        return map { $0[keyPath: keyPath] }
+    }
 }
 
 extension ObservableType where Self.Element: StateType {

--- a/Tests/MiniSwiftTests/RxTests/ObservableTypeTests.swift
+++ b/Tests/MiniSwiftTests/RxTests/ObservableTypeTests.swift
@@ -152,8 +152,7 @@ final class ObservableTypeTests: XCTestCase {
             .disposed(by: disposeBag)
 
         guard let state = try store.dispatch(SetCounterAction(counter: 1))
-            .withStateChanges(in: \.counter)
-            .take(1)
+            .withStateChanges(in: \.counter, that: \.isFulfilled)
             .toBlocking()
             .first() else { fatalError() }
 

--- a/Tests/MiniSwiftTests/RxTests/PrimitiveSequenceTypeTests.swift
+++ b/Tests/MiniSwiftTests/RxTests/PrimitiveSequenceTypeTests.swift
@@ -7,13 +7,13 @@ import RxTest
 @testable import TestMiddleware
 import XCTest
 
-func equalAction<A: Action & Equatable>(_ by: A) -> Predicate<A> {
+func equalAction<A: Action & Equatable>(_ matcher: A) -> Predicate<A> {
     return Predicate { expression in
         guard let action = try expression.evaluate() else {
             return PredicateResult(status: .fail,
                                    message: .fail("failed evaluating expression"))
         }
-        guard action == by else {
+        guard action == matcher else {
             return PredicateResult(status: .fail,
                                    message: .fail("Actions doesn't match"))
         }

--- a/Tests/MiniSwiftTests/RxTests/PrimitiveSequenceTypeTests.swift
+++ b/Tests/MiniSwiftTests/RxTests/PrimitiveSequenceTypeTests.swift
@@ -7,7 +7,7 @@ import RxTest
 @testable import TestMiddleware
 import XCTest
 
-private func equalAction<A: Action & Equatable>(_ by: A) -> Predicate<A> {
+func equalAction<A: Action & Equatable>(_ by: A) -> Predicate<A> {
     return Predicate { expression in
         guard let action = try expression.evaluate() else {
             return PredicateResult(status: .fail,

--- a/Tests/MiniSwiftTests/XCTestManifests.swift
+++ b/Tests/MiniSwiftTests/XCTestManifests.swift
@@ -55,7 +55,9 @@
         // to regenerate.
         static let __allTests__ObservableTypeTests = [
             ("test_dispatch_action_from_store", test_dispatch_action_from_store),
+            ("test_dispatch_from_store", test_dispatch_from_store),
             ("test_dispatch_hashable_action_from_store", test_dispatch_hashable_action_from_store),
+            ("test_dispatch_with_state_changes", test_dispatch_with_state_changes),
             ("test_filter_one", test_filter_one),
         ]
     }

--- a/Tests/MiniSwiftTests/XCTestManifests.swift
+++ b/Tests/MiniSwiftTests/XCTestManifests.swift
@@ -59,6 +59,7 @@
             ("test_dispatch_hashable_action_from_store", test_dispatch_hashable_action_from_store),
             ("test_dispatch_with_state_changes", test_dispatch_with_state_changes),
             ("test_filter_one", test_filter_one),
+            ("test_with_state_changes", test_with_state_changes),
         ]
     }
 


### PR DESCRIPTION
We add two APIs to interact with the `Store` in a more readable and safe way:

``` swift
store.dispatch(SetCounterAction(counter: 1))
         .withStateChanges(in: \.counter)
         .subscribe(...)
```
or
```swift
store.withStateChanges(in: \.counter)
```

This way we want to make more verbose the actions being made and erasing many complexity in the actual API.