### PR TITLE
Added dispatch and action extensions to PrimitiveSequenceType

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,59 @@
 language: swift
-osx_image: xcode11.3
 if: tag is blank
 
 cache:
   bundler: true
   cocoapods: true
-
+  directories:
+    - $TRAVIS_BUILD_DIR/target
+    # https://stackoverflow.com/questions/39930171/cache-brew-builds-with-travis-ci
+    - $HOME/Library/Caches/Homebrew
+    - /usr/local/Homebrew/
+    # used in OSX custom build script dealing with local bottle caching
+    - $HOME/local_bottle_metadata
 addons:
   homebrew:
     brewfile: true
     update: true
 
-script:
-- set -o pipefail
-- swift --version
-- rake
-- rake test
-- bundle exec fastlane pass_tests
-- bundle exec pod repo update
-- rake pods
-- bundle exec danger
+before_install: |
+  if [ -n "$IS_OSX" ]; then
+      TAPS="$(brew --repository)/Library/Taps"
+      if [ -e "$TAPS/caskroom/homebrew-cask" -a -e "$TAPS/homebrew/homebrew-cask" ]; then
+          rm -rf "$TAPS/caskroom/homebrew-cask"
+      fi
+      find "$TAPS" -type d -name .git -exec \
+              bash -xec '
+                  cd $(dirname '\''{}'\'') || echo "status: $?"
+                  git clean -fxd || echo "status: $?"
+                  sleep 1 || echo "status: $?"
+                  git status || echo "status: $?"' \; || echo "status: $?"
+      brew_cache_cleanup
+  fi
+before_cache: |
+  # Cleanup dirs to be cached
+  set -e; set -x
+  if [ -n "$IS_OSX" ]; then
+      # When Taps is cached, this dir causes "Error: file exists" on `brew update`
+      if [ -e "$(brew --repository)/Library/Taps/homebrew/homebrew-cask/homebrew-cask" ]; then
+          rm -rf "$(brew --repository)/Library/Taps/homebrew/homebrew-cask/homebrew-cask"
+      fi
+      brew_cache_cleanup
+  fi
+  set +x; set +e
+
+jobs:
+  include:
+  - stage: Continuous Integration Coverage
+    name: SwiftPM macOS
+    os: osx
+    osx_image: xcode11.3
+    before_script:
+      - bundle install
+    script:
+      - set -o pipefail
+      - rake
+      - bundle exec fastlane pass_tests
+      - bundle exec pod repo update
+      - rake pods
+      - bundle exec danger

--- a/Package.resolved
+++ b/Package.resolved
@@ -20,6 +20,24 @@
         }
       },
       {
+        "package": "CwlCatchException",
+        "repositoryURL": "https://github.com/mattgallagher/CwlCatchException.git",
+        "state": {
+          "branch": null,
+          "revision": "f809deb30dc5c9d9b78c872e553261a61177721a",
+          "version": "2.0.0"
+        }
+      },
+      {
+        "package": "CwlPreconditionTesting",
+        "repositoryURL": "https://github.com/mattgallagher/CwlPreconditionTesting",
+        "state": {
+          "branch": "master",
+          "revision": "02b7a39a99c4da27abe03cab2053a9034379639f",
+          "version": null
+        }
+      },
+      {
         "package": "Komondor",
         "repositoryURL": "https://github.com/shibapm/Komondor.git",
         "state": {
@@ -57,11 +75,11 @@
       },
       {
         "package": "Nimble",
-        "repositoryURL": "https://github.com/Quick/Nimble.git",
+        "repositoryURL": "https://github.com/Quick/Nimble",
         "state": {
           "branch": null,
-          "revision": "f8657642dfdec9973efc79cc68bcef43a653a2bc",
-          "version": "8.0.2"
+          "revision": "b02b00b30b6353632aa4a5fb6124f8147f7140c0",
+          "version": "8.0.5"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -35,10 +35,11 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/ReactiveX/RxSwift.git", from: "5.0.0"),
+        .package(url: "https://github.com/ReactiveX/RxSwift.git", .upToNextMajor(from: "5.0.0")),
         .package(url: "https://github.com/apple/swift-nio.git", .upToNextMajor(from: "2.7.1")),
         // Development
-        .package(url: "https://github.com/Quick/Nimble.git", .exact("8.0.2")), // dev
+        .package(url: "https://github.com/Quick/Nimble", .branch("master")), // dev
+        .package(url: "https://github.com/mattgallagher/CwlPreconditionTesting", .branch("master")), // dev
         .package(url: "https://github.com/minuscorp/ModuleInterface", from: "0.0.1"), // dev
         .package(url: "https://github.com/nicklockwood/SwiftFormat", from: "0.35.8"), // dev
         .package(url: "https://github.com/jpsim/SourceKitten", from: "0.26.0"), // dev
@@ -74,7 +75,7 @@ let package = Package(
         ),
         .testTarget(name: "MiniSwiftTests", dependencies: ["Mini", "MiniTasks", "MiniPromises", "TestMiddleware", "NIOConcurrencyHelpers", "RxSwift", "Nimble", "RxTest", "RxBlocking"]), // dev
     ],
-    swiftLanguageVersions: [.version("4"), .version("4.2"), .version("5")]
+    swiftLanguageVersions: [.version("5.1")]
 )
 
 #if canImport(PackageConfig)

--- a/Rakefile
+++ b/Rakefile
@@ -18,7 +18,7 @@ task(:setup) do
 end
 
 task(:build) do
-  sh('swift build --disable-sandbox -c release')
+  sh("swift build --disable-sandbox -c release")
 end
 
 task(:test) do

--- a/Sources/MiniTasks/Utils/RxSwift/PrimitiveSequenceType+Extensions.swift
+++ b/Sources/MiniTasks/Utils/RxSwift/PrimitiveSequenceType+Extensions.swift
@@ -16,7 +16,6 @@
 
 import RxSwift
 
-// swiftlint:disable explicit_init
 public extension PrimitiveSequenceType where Self: ObservableConvertibleType, Self.Trait == SingleTrait {
     func dispatch<A: CompletableAction>(action: A.Type,
                                         on dispatcher: Dispatcher,

--- a/Sources/MiniTasks/Utils/RxSwift/PrimitiveSequenceType+Extensions.swift
+++ b/Sources/MiniTasks/Utils/RxSwift/PrimitiveSequenceType+Extensions.swift
@@ -1,0 +1,126 @@
+/*
+ Copyright [2019] [BQ]
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import RxSwift
+
+// swiftlint:disable explicit_init
+public extension PrimitiveSequenceType where Self: ObservableConvertibleType, Self.Trait == SingleTrait {
+    func dispatch<A: CompletableAction>(action: A.Type,
+                                        on dispatcher: Dispatcher,
+                                        mode: Dispatcher.DispatchMode.UI = .async,
+                                        fillOnError errorPayload: A.Payload? = nil)
+        -> Disposable where A.Payload == Self.Element {
+        let subscription = subscribe(
+            onSuccess: { payload in
+                let action = A(task: .success(), payload: payload)
+                dispatcher.dispatch(action, mode: mode)
+            },
+            onError: { error in
+                var action: A
+                if let errorPayload = errorPayload {
+                    action = A(task: .success(), payload: errorPayload)
+                } else {
+                    action = A(task: .failure(error), payload: errorPayload)
+                }
+                dispatcher.dispatch(action, mode: mode)
+            }
+        )
+        return subscription
+    }
+
+    func dispatch<A: KeyedCompletableAction>(action: A.Type,
+                                             key: A.Key,
+                                             on dispatcher: Dispatcher,
+                                             mode: Dispatcher.DispatchMode.UI = .async,
+                                             fillOnError errorPayload: A.Payload? = nil)
+        -> Disposable where A.Payload == Self.Element {
+        let subscription = subscribe(
+            onSuccess: { payload in
+                let action = A(task: .success(), payload: payload, key: key)
+                dispatcher.dispatch(action, mode: mode)
+            },
+            onError: { error in
+                var action: A
+                if let errorPayload = errorPayload {
+                    action = A(task: .success(), payload: errorPayload, key: key)
+                } else {
+                    action = A(task: .failure(error), payload: errorPayload, key: key)
+                }
+                dispatcher.dispatch(action, mode: mode)
+            }
+        )
+        return subscription
+    }
+
+    func action<A: CompletableAction>(_ action: A.Type,
+                                      fillOnError errorPayload: A.Payload? = nil)
+        -> Single<A> where A.Payload == Self.Element {
+        return Single<A>.create { single in
+            let subscription = self.subscribe(
+                onSuccess: { payload in
+                    let action = A(task: .success(), payload: payload)
+                    single(.success(action))
+                },
+                onError: { error in
+                    var action: A
+                    if let errorPayload = errorPayload {
+                        action = A(task: .success(), payload: errorPayload)
+                    } else {
+                        action = A(task: .failure(error), payload: errorPayload)
+                    }
+                    single(.success(action))
+                }
+            )
+            return Disposables.create([subscription])
+        }
+    }
+}
+
+public extension PrimitiveSequenceType where Trait == CompletableTrait, Element == Swift.Never {
+    func dispatch<A: EmptyAction>(action: A.Type,
+                                  on dispatcher: Dispatcher,
+                                  mode: Dispatcher.DispatchMode.UI = .async)
+        -> Disposable {
+        let subscription = subscribe { completable in
+            switch completable {
+            case .completed:
+                let action = A(task: .success())
+                dispatcher.dispatch(action, mode: mode)
+            case let .error(error):
+                let action = A(task: .failure(error))
+                dispatcher.dispatch(action, mode: mode)
+            }
+        }
+        return subscription
+    }
+
+    func action<A: EmptyAction>(_ action: A.Type)
+        -> Single<A> {
+        return Single.create { single in
+            let subscription = self.subscribe { event in
+                switch event {
+                case .completed:
+                    let action = A(task: .success())
+                    single(.success(action))
+                case let .error(error):
+                    let action = A(task: .failure(error))
+                    single(.success(action))
+                }
+            }
+            return Disposables.create([subscription])
+        }
+    }
+}

--- a/Sources/MiniTasks/Utils/RxSwift/PrimitiveSequenceType+Extensions.swift
+++ b/Sources/MiniTasks/Utils/RxSwift/PrimitiveSequenceType+Extensions.swift
@@ -17,6 +17,13 @@
 import RxSwift
 
 public extension PrimitiveSequenceType where Self: ObservableConvertibleType, Self.Trait == SingleTrait {
+    /**
+     Dispatches an given action from the result of the `Single` trait. This is only usable when the `Action` is a `CompletableAction`.
+     - Parameter action: The `CompletableAction` type to be dispatched.
+     - Parameter dispatcher: The `Dispatcher` object that will dispatch the action.
+     - Parameter mode: The `Dispatcher` dispatch mode, `.async` by default.
+     - Parameter fillOnError: The payload that will replace the action's payload in case of failure.
+     */
     func dispatch<A: CompletableAction>(action: A.Type,
                                         on dispatcher: Dispatcher,
                                         mode: Dispatcher.DispatchMode.UI = .async,
@@ -40,6 +47,14 @@ public extension PrimitiveSequenceType where Self: ObservableConvertibleType, Se
         return subscription
     }
 
+    /**
+     Dispatches an given action from the result of the `Single` trait. This is only usable when the `Action` is a `CompletableAction`.
+     - Parameter action: The `CompletableAction` type to be dispatched.
+     - Parameter key: The key associated with the `Task` result.
+     - Parameter dispatcher: The `Dispatcher` object that will dispatch the action.
+     - Parameter mode: The `Dispatcher` dispatch mode, `.async` by default.
+     - Parameter fillOnError: The payload that will replace the action's payload in case of failure or `nil`.
+     */
     func dispatch<A: KeyedCompletableAction>(action: A.Type,
                                              key: A.Key,
                                              on dispatcher: Dispatcher,
@@ -64,6 +79,12 @@ public extension PrimitiveSequenceType where Self: ObservableConvertibleType, Se
         return subscription
     }
 
+    /**
+     Builds a `CompletableAction` from a `Single`
+     - Parameter action: The `CompletableAction` type to be built.
+     - Parameter fillOnError: The payload that will replace the action's payload in case of failure or `nil`.
+     - Returns: A `Single` of the `CompletableAction` type declared by the action parameter.
+     */
     func action<A: CompletableAction>(_ action: A.Type,
                                       fillOnError errorPayload: A.Payload? = nil)
         -> Single<A> where A.Payload == Self.Element {
@@ -89,6 +110,12 @@ public extension PrimitiveSequenceType where Self: ObservableConvertibleType, Se
 }
 
 public extension PrimitiveSequenceType where Trait == CompletableTrait, Element == Swift.Never {
+    /**
+     Dispatches an given action from the result of the `Completable` trait. This is only usable when the `Action` is an `EmptyAction`.
+     - Parameter action: The `CompletableAction` type to be dispatched.
+     - Parameter dispatcher: The `Dispatcher` object that will dispatch the action.
+     - Parameter mode: The `Dispatcher` dispatch mode, `.async` by default.
+     */
     func dispatch<A: EmptyAction>(action: A.Type,
                                   on dispatcher: Dispatcher,
                                   mode: Dispatcher.DispatchMode.UI = .async)
@@ -106,6 +133,11 @@ public extension PrimitiveSequenceType where Trait == CompletableTrait, Element 
         return subscription
     }
 
+    /**
+     Builds an `EmptyAction` from a `Completable`
+     - Parameter action: The `EmptyAction` type to be built.
+     - Returns: A `Single` of the `EmptyAction` type declared by the action parameter.
+     */
     func action<A: EmptyAction>(_ action: A.Type)
         -> Single<A> {
         return Single.create { single in

--- a/Tests/MiniSwiftTests/ActionTests.swift
+++ b/Tests/MiniSwiftTests/ActionTests.swift
@@ -1,10 +1,24 @@
 @testable import Mini
+@testable import MiniTasks
+import Nimble
 import XCTest
 
 final class ActionTests: XCTestCase {
+    struct TasksTestEmptyAction: MiniTasks.EmptyAction {
+        let task: AnyTask
+    }
+
     func test_action_tag() {
         let action = SetCounterAction(counter: 1)
 
         XCTAssertEqual(String(describing: type(of: action)), SetCounterAction.tag)
     }
+
+    #if !SWIFT_PACKAGE
+        func test_empty_action_fatal_error_initializer() {
+            expect {
+                _ = TasksTestEmptyAction(task: .success(), payload: nil)
+            }.to(throwAssertion())
+        }
+    #endif
 }

--- a/Tests/MiniSwiftTests/ActionTests.swift
+++ b/Tests/MiniSwiftTests/ActionTests.swift
@@ -14,11 +14,9 @@ final class ActionTests: XCTestCase {
         XCTAssertEqual(String(describing: type(of: action)), SetCounterAction.tag)
     }
 
-    #if !SWIFT_PACKAGE
-        func test_empty_action_fatal_error_initializer() {
-            expect {
-                _ = TasksTestEmptyAction(task: .success(), payload: nil)
-            }.to(throwAssertion())
-        }
-    #endif
+    func test_empty_action_fatal_error_initializer() {
+        expect {
+            _ = TasksTestEmptyAction(task: .success(), payload: nil)
+        }.to(throwAssertion())
+    }
 }

--- a/Tests/MiniSwiftTests/RxTests/PrimitiveSequenceTypeTests.swift
+++ b/Tests/MiniSwiftTests/RxTests/PrimitiveSequenceTypeTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 @testable import MiniPromises
+@testable import MiniTasks
 import Nimble
 import RxBlocking
 import RxSwift
@@ -25,46 +26,72 @@ private func equalAction<A: Action & Equatable>(_ by: A) -> Predicate<A> {
 final class PrimitiveSequenceTypeTests: XCTestCase {
     fileprivate enum Error: Swift.Error { case dummy }
 
-    class TestCompletableAction: CompletableAction, Equatable {
+    // MARK: - Promises test actions.
+
+    struct PromisesTestCompletableAction: MiniPromises.CompletableAction, Equatable {
         typealias Payload = Int
 
-        let counter: Promise<Payload>
+        let promise: Promise<Payload>
 
-        required init(promise: Promise<Payload>) {
-            counter = promise
-        }
-
-        static func == (lhs: TestCompletableAction, rhs: TestCompletableAction) -> Bool {
-            lhs.counter == rhs.counter
+        static func == (lhs: PromisesTestCompletableAction, rhs: PromisesTestCompletableAction) -> Bool {
+            lhs.promise == rhs.promise
         }
     }
 
-    class TestKeyedCompletableAction: KeyedCompletableAction, Equatable {
+    struct PromisesTestKeyedCompletableAction: MiniPromises.KeyedCompletableAction, Equatable {
         typealias Payload = Int
         typealias Key = String
 
-        let counterMap: [Key: Promise<Payload>]
+        let promise: [Key: Promise<Payload>]
 
-        required init(promise: [Key: Promise<Payload>]) {
-            counterMap = promise
-        }
-
-        static func == (lhs: TestKeyedCompletableAction, rhs: TestKeyedCompletableAction) -> Bool {
-            lhs.counterMap == rhs.counterMap
+        static func == (lhs: PromisesTestKeyedCompletableAction, rhs: PromisesTestKeyedCompletableAction) -> Bool {
+            lhs.promise == rhs.promise
         }
     }
 
-    class TestEmptyAction: EmptyAction, Equatable {
+    struct PromisesTestEmptyAction: MiniPromises.EmptyAction, Equatable {
         let promise: Promise<Void>
 
-        required init(promise: Promise<Void>) {
-            self.promise = promise
-        }
-
-        static func == (_: TestEmptyAction, _: TestEmptyAction) -> Bool {
+        static func == (_: PromisesTestEmptyAction, _: PromisesTestEmptyAction) -> Bool {
             true
         }
     }
+
+    // MARK: - Tasks test actions.
+
+    struct TasksTestCompletableAction: MiniTasks.CompletableAction, Equatable {
+        typealias Payload = Int
+
+        let task: AnyTask
+        let payload: Payload?
+
+        static func == (lhs: TasksTestCompletableAction, rhs: TasksTestCompletableAction) -> Bool {
+            lhs.payload == rhs.payload && lhs.task.status == rhs.task.status
+        }
+    }
+
+    struct TasksTestKeyedCompletableAction: MiniTasks.KeyedCompletableAction, Equatable {
+        typealias Payload = Int
+        typealias Key = String
+
+        let task: AnyTask
+        let payload: Int?
+        let key: Key
+
+        static func == (lhs: TasksTestKeyedCompletableAction, rhs: TasksTestKeyedCompletableAction) -> Bool {
+            lhs.key == rhs.key && lhs.payload == rhs.payload && lhs.task.status == rhs.task.status
+        }
+    }
+
+    struct TasksTestEmptyAction: MiniTasks.EmptyAction, Equatable {
+        let task: AnyTask
+
+        static func == (lhs: TasksTestEmptyAction, rhs: TasksTestEmptyAction) -> Bool {
+            lhs.task.status == rhs.task.status
+        }
+    }
+
+    // MARK: - Common
 
     var dispatcher: Dispatcher!
     var disposeBag: DisposeBag!
@@ -79,99 +106,199 @@ final class PrimitiveSequenceTypeTests: XCTestCase {
         dispatcher.add(middleware: testMiddleware)
     }
 
-    func test_completable_action_dispatch() {
+    // MARK: - Promises tests
+
+    func test_promises_completable_action_dispatch() {
         Single
             .just(1)
-            .dispatch(action: TestCompletableAction.self, on: dispatcher)
+            .dispatch(action: PromisesTestCompletableAction.self, on: dispatcher)
             .disposed(by: disposeBag)
 
         expect(
-            self.testMiddleware.actions(of: TestCompletableAction.self).count
+            self.testMiddleware.actions(of: PromisesTestCompletableAction.self).count
         ).toEventually(be(1))
     }
 
-    func test_completable_action_dispatch_error() {
+    func test_promises_completable_action_dispatch_error() {
         Single
             .error(Error.dummy)
-            .dispatch(action: TestCompletableAction.self, on: dispatcher)
+            .dispatch(action: PromisesTestCompletableAction.self, on: dispatcher)
             .disposed(by: disposeBag)
 
         expect(
-            self.testMiddleware.actions(of: TestCompletableAction.self).count
+            self.testMiddleware.actions(of: PromisesTestCompletableAction.self).count
         ).toEventually(be(1))
 
         expect(
-            self.testMiddleware.action(of: TestCompletableAction.self) {
-                $0.counter == .error(Error.dummy)
+            self.testMiddleware.action(of: PromisesTestCompletableAction.self) {
+                $0.promise == .error(Error.dummy)
             }
         ).toEventually(beTrue())
     }
 
-    func test_keyed_completable_action_dispatch() {
+    func test_promises_keyed_completable_action_dispatch() {
         Single
             .just(1)
-            .dispatch(action: TestKeyedCompletableAction.self, key: "hello", on: dispatcher)
+            .dispatch(action: PromisesTestKeyedCompletableAction.self, key: "hello", on: dispatcher)
             .disposed(by: disposeBag)
 
         expect(
             self.testMiddleware
-                .action(of: TestKeyedCompletableAction.self) {
-                    $0.counterMap == ["hello": .value(1)]
+                .action(of: PromisesTestKeyedCompletableAction.self) {
+                    $0.promise == ["hello": .value(1)]
                 }
         ).toEventually(beTrue())
     }
 
-    func test_keyed_completable_action_dispatch_error() {
+    func test_promises_keyed_completable_action_dispatch_error() {
         Single
             .error(Error.dummy)
-            .dispatch(action: TestKeyedCompletableAction.self, key: "hello", on: dispatcher)
+            .dispatch(action: PromisesTestKeyedCompletableAction.self, key: "hello", on: dispatcher)
             .disposed(by: disposeBag)
 
         expect(
             self.testMiddleware
-                .action(of: TestKeyedCompletableAction.self) {
-                    $0.counterMap == ["hello": .error(Error.dummy)]
+                .action(of: PromisesTestKeyedCompletableAction.self) {
+                    $0.promise == ["hello": .error(Error.dummy)]
                 }
         ).toEventually(beTrue())
     }
 
-    func test_completable_action_action() throws {
+    func test_promises_completable_action_action() throws {
         guard let action =
             try Single
             .just(1)
-            .action(TestCompletableAction.self)
+            .action(PromisesTestCompletableAction.self)
             .toBlocking(timeout: 5.0).first() else { fatalError() }
 
-        expect(action).to(equalAction(TestCompletableAction(promise: .value(1))))
+        expect(action).to(equalAction(PromisesTestCompletableAction(promise: .value(1))))
     }
 
-    func test_empty_action_dispatch() {
+    func test_promises_empty_action_dispatch() {
         Completable
             .empty()
-            .dispatch(action: TestEmptyAction.self, on: dispatcher)
+            .dispatch(action: PromisesTestEmptyAction.self, on: dispatcher)
             .disposed(by: disposeBag)
 
         expect(
-            self.testMiddleware.actions(of: TestEmptyAction.self).count
+            self.testMiddleware.actions(of: PromisesTestEmptyAction.self).count
         ).toEventually(be(1))
 
-        expect(self.testMiddleware.actions(of: TestEmptyAction.self).first?.promise.isResolved) == true
+        expect(self.testMiddleware.actions(of: PromisesTestEmptyAction.self).first?.promise.isResolved) == true
     }
 
-    func test_empty_action_dispatch_error() {
+    func test_promises_empty_action_dispatch_error() {
         Completable
             .error(Error.dummy)
-            .dispatch(action: TestEmptyAction.self, on: dispatcher)
+            .dispatch(action: PromisesTestEmptyAction.self, on: dispatcher)
             .disposed(by: disposeBag)
 
         expect(
-            self.testMiddleware.actions(of: TestEmptyAction.self).count
+            self.testMiddleware.actions(of: PromisesTestEmptyAction.self).count
         ).toEventually(be(1))
 
-        expect(self.testMiddleware.actions(of: TestEmptyAction.self).first?.promise.isResolved) == true
+        expect(self.testMiddleware.actions(of: PromisesTestEmptyAction.self).first?.promise.isResolved) == true
 
-        expect(self.testMiddleware.actions(of: TestEmptyAction.self).first?.promise.isCompleted) == true
+        expect(self.testMiddleware.actions(of: PromisesTestEmptyAction.self).first?.promise.isCompleted) == true
 
-        expect(self.testMiddleware.actions(of: TestEmptyAction.self).first?.promise.isRejected) == true
+        expect(self.testMiddleware.actions(of: PromisesTestEmptyAction.self).first?.promise.isRejected) == true
+    }
+
+    // MARK: - Tasks tests
+
+    func test_tasks_completable_action_dispatch() {
+        Single
+            .just(1)
+            .dispatch(action: TasksTestCompletableAction.self, on: dispatcher)
+            .disposed(by: disposeBag)
+
+        expect(
+            self.testMiddleware.actions(of: TasksTestCompletableAction.self).count
+        ).toEventually(be(1))
+    }
+
+    func test_tasks_completable_action_dispatch_error() {
+        Single
+            .error(Error.dummy)
+            .dispatch(action: TasksTestCompletableAction.self, on: dispatcher)
+            .disposed(by: disposeBag)
+
+        expect(
+            self.testMiddleware.actions(of: TasksTestCompletableAction.self).count
+        ).toEventually(be(1))
+
+        expect(
+            self.testMiddleware.action(of: TasksTestCompletableAction.self) {
+                $0.task.error as? Error == Error.dummy
+            }
+        ).toEventually(beTrue())
+    }
+
+    func test_tasks_keyed_completable_action_dispatch() {
+        Single
+            .just(1)
+            .dispatch(action: TasksTestKeyedCompletableAction.self, key: "hello", on: dispatcher)
+            .disposed(by: disposeBag)
+
+        expect(
+            self.testMiddleware
+                .action(of: TasksTestKeyedCompletableAction.self) {
+                    $0.payload == 1 && $0.key == "hello" && $0.task.status == .success
+                }
+        ).toEventually(beTrue())
+    }
+
+    func test_tasks_keyed_completable_action_dispatch_error() {
+        Single
+            .error(Error.dummy)
+            .dispatch(action: TasksTestKeyedCompletableAction.self, key: "hello", on: dispatcher)
+            .disposed(by: disposeBag)
+
+        expect(
+            self.testMiddleware
+                .action(of: TasksTestKeyedCompletableAction.self) {
+                    $0.payload == nil && $0.key == "hello" && $0.task.status == .error
+                }
+        ).toEventually(beTrue())
+    }
+
+    func test_tasks_completable_action_action() throws {
+        guard let action =
+            try Single
+            .just(1)
+            .action(TasksTestCompletableAction.self)
+            .toBlocking(timeout: 5.0).first() else { fatalError() }
+
+        expect(action).to(equalAction(TasksTestCompletableAction(task: .success(), payload: 1)))
+    }
+
+    func test_tasks_empty_action_dispatch() {
+        Completable
+            .empty()
+            .dispatch(action: TasksTestEmptyAction.self, on: dispatcher)
+            .disposed(by: disposeBag)
+
+        expect(
+            self.testMiddleware.actions(of: TasksTestEmptyAction.self).count
+        ).toEventually(be(1))
+
+        expect(self.testMiddleware.actions(of: TasksTestEmptyAction.self).first?.task.isCompleted) == true
+    }
+
+    func test_tasks_empty_action_dispatch_error() {
+        Completable
+            .error(Error.dummy)
+            .dispatch(action: TasksTestEmptyAction.self, on: dispatcher)
+            .disposed(by: disposeBag)
+
+        expect(
+            self.testMiddleware.actions(of: TasksTestEmptyAction.self).count
+        ).toEventually(be(1))
+
+        expect(self.testMiddleware.actions(of: TasksTestEmptyAction.self).first?.task.isRunning) == false
+
+        expect(self.testMiddleware.actions(of: TasksTestEmptyAction.self).first?.task.isCompleted) == true
+
+        expect(self.testMiddleware.actions(of: TasksTestEmptyAction.self).first?.task.isFailure) == true
     }
 }

--- a/Tests/MiniSwiftTests/RxTests/PrimitiveSequenceTypeTests.swift
+++ b/Tests/MiniSwiftTests/RxTests/PrimitiveSequenceTypeTests.swift
@@ -119,6 +119,19 @@ final class PrimitiveSequenceTypeTests: XCTestCase {
         ).toEventually(be(1))
     }
 
+    func test_promises_completable_action_dispatch_fill_on_error() {
+        Single
+            .error(Error.dummy)
+            .dispatch(action: PromisesTestCompletableAction.self, on: dispatcher, fillOnError: 1)
+            .disposed(by: disposeBag)
+
+        expect(
+            self.testMiddleware.actions(of: PromisesTestCompletableAction.self).count
+        ).toEventually(be(1))
+
+        expect(self.testMiddleware.actions(of: PromisesTestCompletableAction.self).first?.promise.value) == 1
+    }
+
     func test_promises_completable_action_dispatch_error() {
         Single
             .error(Error.dummy)
@@ -140,6 +153,20 @@ final class PrimitiveSequenceTypeTests: XCTestCase {
         Single
             .just(1)
             .dispatch(action: PromisesTestKeyedCompletableAction.self, key: "hello", on: dispatcher)
+            .disposed(by: disposeBag)
+
+        expect(
+            self.testMiddleware
+                .action(of: PromisesTestKeyedCompletableAction.self) {
+                    $0.promise == ["hello": .value(1)]
+                }
+        ).toEventually(beTrue())
+    }
+
+    func test_promises_keyed_completable_action_dispatch_fill_on_error() {
+        Single
+            .error(Error.dummy)
+            .dispatch(action: PromisesTestKeyedCompletableAction.self, key: "hello", on: dispatcher, fillOnError: 1)
             .disposed(by: disposeBag)
 
         expect(
@@ -172,6 +199,46 @@ final class PrimitiveSequenceTypeTests: XCTestCase {
             .toBlocking(timeout: 5.0).first() else { fatalError() }
 
         expect(action).to(equalAction(PromisesTestCompletableAction(promise: .value(1))))
+    }
+
+    func test_promises_completable_action_action_fill_on_error() throws {
+        guard let action =
+            try Single
+            .error(Error.dummy)
+            .action(PromisesTestCompletableAction.self, fillOnError: 1)
+            .toBlocking(timeout: 5.0).first() else { fatalError() }
+
+        expect(action).to(equalAction(PromisesTestCompletableAction(promise: .value(1))))
+    }
+
+    func test_promises_completable_action_action_error() throws {
+        guard let action =
+            try Single
+            .error(Error.dummy)
+            .action(PromisesTestCompletableAction.self)
+            .toBlocking(timeout: 5.0).first() else { fatalError() }
+
+        expect(action).to(equalAction(PromisesTestCompletableAction(promise: .error(Error.dummy))))
+    }
+
+    func test_promises_empty_action_action() throws {
+        guard let action =
+            try Completable
+            .empty()
+            .action(PromisesTestEmptyAction.self)
+            .toBlocking(timeout: 5.0).first() else { fatalError() }
+
+        expect(action).to(equalAction(PromisesTestEmptyAction(promise: .empty())))
+    }
+
+    func test_promises_empty_action_action_error() throws {
+        guard let action =
+            try Completable
+            .error(Error.dummy)
+            .action(PromisesTestEmptyAction.self)
+            .toBlocking(timeout: 5.0).first() else { fatalError() }
+
+        expect(action).to(equalAction(PromisesTestEmptyAction(promise: .error(Error.dummy))))
     }
 
     func test_promises_empty_action_dispatch() {
@@ -217,6 +284,19 @@ final class PrimitiveSequenceTypeTests: XCTestCase {
         ).toEventually(be(1))
     }
 
+    func test_tasks_completable_action_dispatch_fill_on_error() {
+        Single
+            .error(Error.dummy)
+            .dispatch(action: TasksTestCompletableAction.self, on: dispatcher, fillOnError: 1)
+            .disposed(by: disposeBag)
+
+        expect(
+            self.testMiddleware.actions(of: TasksTestCompletableAction.self).count
+        ).toEventually(be(1))
+
+        expect(self.testMiddleware.actions(of: TasksTestCompletableAction.self).first?.payload) == 1
+    }
+
     func test_tasks_completable_action_dispatch_error() {
         Single
             .error(Error.dummy)
@@ -238,6 +318,20 @@ final class PrimitiveSequenceTypeTests: XCTestCase {
         Single
             .just(1)
             .dispatch(action: TasksTestKeyedCompletableAction.self, key: "hello", on: dispatcher)
+            .disposed(by: disposeBag)
+
+        expect(
+            self.testMiddleware
+                .action(of: TasksTestKeyedCompletableAction.self) {
+                    $0.payload == 1 && $0.key == "hello" && $0.task.status == .success
+                }
+        ).toEventually(beTrue())
+    }
+
+    func test_tasks_keyed_completable_action_dispatch_fill_on_error() {
+        Single
+            .error(Error.dummy)
+            .dispatch(action: TasksTestKeyedCompletableAction.self, key: "hello", on: dispatcher, fillOnError: 1)
             .disposed(by: disposeBag)
 
         expect(
@@ -270,6 +364,46 @@ final class PrimitiveSequenceTypeTests: XCTestCase {
             .toBlocking(timeout: 5.0).first() else { fatalError() }
 
         expect(action).to(equalAction(TasksTestCompletableAction(task: .success(), payload: 1)))
+    }
+
+    func test_tasks_completable_action_action_fill_on_error() throws {
+        guard let action =
+            try Single
+            .error(Error.dummy)
+            .action(TasksTestCompletableAction.self, fillOnError: 1)
+            .toBlocking(timeout: 5.0).first() else { fatalError() }
+
+        expect(action).to(equalAction(TasksTestCompletableAction(task: .success(), payload: 1)))
+    }
+
+    func test_tasks_completable_action_action_error() throws {
+        guard let action =
+            try Single
+            .error(Error.dummy)
+            .action(TasksTestCompletableAction.self)
+            .toBlocking(timeout: 5.0).first() else { fatalError() }
+
+        expect(action).to(equalAction(TasksTestCompletableAction(task: .failure(Error.dummy), payload: nil)))
+    }
+
+    func test_tasks_empty_action_action() throws {
+        guard let action =
+            try Completable
+            .empty()
+            .action(TasksTestEmptyAction.self)
+            .toBlocking(timeout: 5.0).first() else { fatalError() }
+
+        expect(action).to(equalAction(TasksTestEmptyAction(task: .success())))
+    }
+
+    func test_tasks_empty_action_action_error() throws {
+        guard let action =
+            try Completable
+            .error(Error.dummy)
+            .action(TasksTestEmptyAction.self)
+            .toBlocking(timeout: 5.0).first() else { fatalError() }
+
+        expect(action).to(equalAction(TasksTestEmptyAction(task: .failure(Error.dummy))))
     }
 
     func test_tasks_empty_action_dispatch() {

--- a/Tests/MiniSwiftTests/TaskTests.swift
+++ b/Tests/MiniSwiftTests/TaskTests.swift
@@ -4,6 +4,18 @@ import XCTest
 class TaskTests: XCTestCase {
     let error = NSError(domain: #function, code: -1, userInfo: nil)
 
+    func test_check_states_for_idle_task() {
+        let task = AnyTask.idle()
+
+        XCTAssertEqual(task.status, .idle)
+        XCTAssertNil(task.error)
+
+        XCTAssertFalse(task.isRunning)
+        XCTAssertFalse(task.isFailure)
+        XCTAssertFalse(task.isCompleted)
+        XCTAssertFalse(task.isSuccessful)
+    }
+
     func test_check_states_for_running_task() {
         let task = AnyTask.running()
 
@@ -28,6 +40,19 @@ class TaskTests: XCTestCase {
         XCTAssertTrue(task.isSuccessful)
     }
 
+    func test_check_states_for_success_typed_task() {
+        let task: TypedTask<Int> = AnyTask.success(1)
+
+        XCTAssertEqual(task.status, .success)
+        XCTAssertNil(task.error)
+
+        XCTAssertFalse(task.isRunning)
+        XCTAssertFalse(task.isFailure)
+        XCTAssertTrue(task.isCompleted)
+        XCTAssertTrue(task.isSuccessful)
+        XCTAssertEqual(task.data, 1)
+    }
+
     func test_check_states_for_failure_task() {
         let task = AnyTask.failure(error)
 
@@ -38,5 +63,14 @@ class TaskTests: XCTestCase {
         XCTAssertTrue(task.isFailure)
         XCTAssertTrue(task.isCompleted)
         XCTAssertFalse(task.isSuccessful)
+    }
+
+    func test_task_properties() {
+        let task: AnyTask = .idle()
+        let date = Date()
+        task.date = date
+
+        XCTAssertEqual(task.date as Date?, date)
+        XCTAssertNil(task.not_a_property as Int?)
     }
 }

--- a/Tests/MiniSwiftTests/XCTestManifests.swift
+++ b/Tests/MiniSwiftTests/XCTestManifests.swift
@@ -71,20 +71,32 @@
     //   `swift test --generate-linuxmain`
         // to regenerate.
         static let __allTests__PrimitiveSequenceTypeTests = [
+            ("test_promises_completable_action_action_error", test_promises_completable_action_action_error),
+            ("test_promises_completable_action_action_fill_on_error", test_promises_completable_action_action_fill_on_error),
             ("test_promises_completable_action_action", test_promises_completable_action_action),
             ("test_promises_completable_action_dispatch", test_promises_completable_action_dispatch),
             ("test_promises_completable_action_dispatch_error", test_promises_completable_action_dispatch_error),
+            ("test_promises_completable_action_dispatch_fill_on_error", test_promises_completable_action_dispatch_fill_on_error),
+            ("test_promises_empty_action_action_error", test_promises_empty_action_action_error),
+            ("test_promises_empty_action_action", test_promises_empty_action_action),
             ("test_promises_empty_action_dispatch", test_promises_empty_action_dispatch),
             ("test_promises_empty_action_dispatch_error", test_promises_empty_action_dispatch_error),
             ("test_promises_keyed_completable_action_dispatch", test_promises_keyed_completable_action_dispatch),
             ("test_promises_keyed_completable_action_dispatch_error", test_promises_keyed_completable_action_dispatch_error),
+            ("test_promises_keyed_completable_action_dispatch_fill_on_error", test_promises_keyed_completable_action_dispatch_fill_on_error),
+            ("test_tasks_completable_action_action_error", test_tasks_completable_action_action_error),
+            ("test_tasks_completable_action_action_fill_on_error", test_tasks_completable_action_action_fill_on_error),
             ("test_tasks_completable_action_action", test_tasks_completable_action_action),
             ("test_tasks_completable_action_dispatch", test_tasks_completable_action_dispatch),
             ("test_tasks_completable_action_dispatch_error", test_tasks_completable_action_dispatch_error),
+            ("test_tasks_completable_action_dispatch_fill_on_error", test_tasks_completable_action_dispatch_fill_on_error),
+            ("test_tasks_empty_action_action_error", test_tasks_empty_action_action_error),
+            ("test_tasks_empty_action_action", test_tasks_empty_action_action),
             ("test_tasks_empty_action_dispatch", test_tasks_empty_action_dispatch),
             ("test_tasks_empty_action_dispatch_error", test_tasks_empty_action_dispatch_error),
             ("test_tasks_keyed_completable_action_dispatch", test_tasks_keyed_completable_action_dispatch),
             ("test_tasks_keyed_completable_action_dispatch_error", test_tasks_keyed_completable_action_dispatch_error),
+            ("test_tasks_keyed_completable_action_dispatch_fill_on_error", test_tasks_keyed_completable_action_dispatch_fill_on_error),
         ]
     }
 
@@ -130,8 +142,11 @@
         // to regenerate.
         static let __allTests__TaskTests = [
             ("test_check_states_for_failure_task", test_check_states_for_failure_task),
+            ("test_check_states_for_idle_task", test_check_states_for_idle_task),
             ("test_check_states_for_running_task", test_check_states_for_running_task),
             ("test_check_states_for_success_task", test_check_states_for_success_task),
+            ("test_check_states_for_success_typed_task", test_check_states_for_success_typed_task),
+            ("test_task_properties", test_task_properties),
         ]
     }
 

--- a/Tests/MiniSwiftTests/XCTestManifests.swift
+++ b/Tests/MiniSwiftTests/XCTestManifests.swift
@@ -7,6 +7,7 @@
         // to regenerate.
         static let __allTests__ActionTests = [
             ("test_action_tag", test_action_tag),
+            ("test_empty_action_fatal_error_initializer", test_empty_action_fatal_error_initializer),
         ]
     }
 

--- a/Tests/MiniSwiftTests/XCTestManifests.swift
+++ b/Tests/MiniSwiftTests/XCTestManifests.swift
@@ -71,13 +71,20 @@
     //   `swift test --generate-linuxmain`
         // to regenerate.
         static let __allTests__PrimitiveSequenceTypeTests = [
-            ("test_completable_action_action", test_completable_action_action),
-            ("test_completable_action_dispatch", test_completable_action_dispatch),
-            ("test_completable_action_dispatch_error", test_completable_action_dispatch_error),
-            ("test_empty_action_dispatch", test_empty_action_dispatch),
-            ("test_empty_action_dispatch_error", test_empty_action_dispatch_error),
-            ("test_keyed_completable_action_dispatch", test_keyed_completable_action_dispatch),
-            ("test_keyed_completable_action_dispatch_error", test_keyed_completable_action_dispatch_error),
+            ("test_promises_completable_action_action", test_promises_completable_action_action),
+            ("test_promises_completable_action_dispatch", test_promises_completable_action_dispatch),
+            ("test_promises_completable_action_dispatch_error", test_promises_completable_action_dispatch_error),
+            ("test_promises_empty_action_dispatch", test_promises_empty_action_dispatch),
+            ("test_promises_empty_action_dispatch_error", test_promises_empty_action_dispatch_error),
+            ("test_promises_keyed_completable_action_dispatch", test_promises_keyed_completable_action_dispatch),
+            ("test_promises_keyed_completable_action_dispatch_error", test_promises_keyed_completable_action_dispatch_error),
+            ("test_tasks_completable_action_action", test_tasks_completable_action_action),
+            ("test_tasks_completable_action_dispatch", test_tasks_completable_action_dispatch),
+            ("test_tasks_completable_action_dispatch_error", test_tasks_completable_action_dispatch_error),
+            ("test_tasks_empty_action_dispatch", test_tasks_empty_action_dispatch),
+            ("test_tasks_empty_action_dispatch_error", test_tasks_empty_action_dispatch_error),
+            ("test_tasks_keyed_completable_action_dispatch", test_tasks_keyed_completable_action_dispatch),
+            ("test_tasks_keyed_completable_action_dispatch_error", test_tasks_keyed_completable_action_dispatch_error),
         ]
     }
 

--- a/docs/MiniTasks.swift
+++ b/docs/MiniTasks.swift
@@ -96,3 +96,17 @@ extension ObservableType where Self.Element: Mini.StateType {
      */
     public func withStateChanges<T, Type, U>(in stateComponent: KeyPath<Self.Element, T>, that taskComponent: KeyPath<Self.Element, U>) -> RxSwift.Observable<T> where U: MiniTasks.TypedTask<Type>
 }
+
+extension PrimitiveSequenceType where Self: RxSwift.ObservableConvertibleType, Self.Trait == RxSwift.SingleTrait {
+    public func dispatch<A>(action: A.Type, on dispatcher: Mini.Dispatcher, mode: Mini.Dispatcher.DispatchMode.UI = .async, fillOnError errorPayload: A.Payload? = nil) -> RxSwift.Disposable where A: MiniTasks.CompletableAction, Self.Element == A.Payload
+
+    public func dispatch<A>(action: A.Type, key: A.Key, on dispatcher: Mini.Dispatcher, mode: Mini.Dispatcher.DispatchMode.UI = .async, fillOnError errorPayload: A.Payload? = nil) -> RxSwift.Disposable where A: MiniTasks.KeyedCompletableAction, Self.Element == A.Payload
+
+    public func action<A>(_ action: A.Type, fillOnError errorPayload: A.Payload? = nil) -> RxSwift.Single<A> where A: MiniTasks.CompletableAction, Self.Element == A.Payload
+}
+
+extension PrimitiveSequenceType where Self.Element == Never, Self.Trait == RxSwift.CompletableTrait {
+    public func dispatch<A>(action: A.Type, on dispatcher: Mini.Dispatcher, mode: Mini.Dispatcher.DispatchMode.UI = .async) -> RxSwift.Disposable where A: MiniTasks.EmptyAction
+
+    public func action<A>(_ action: A.Type) -> RxSwift.Single<A> where A: MiniTasks.EmptyAction
+}

--- a/docs/MiniTasks/README.md
+++ b/docs/MiniTasks/README.md
@@ -18,6 +18,7 @@
 
 -   [EmptyAction](extensions/EmptyAction.md)
 -   [ObservableType](extensions/ObservableType.md)
+-   [PrimitiveSequenceType](extensions/PrimitiveSequenceType.md)
 
 # Reference Documentation
 This reference documentation was generated with

--- a/docs/MiniTasks/extensions/PrimitiveSequenceType.md
+++ b/docs/MiniTasks/extensions/PrimitiveSequenceType.md
@@ -1,0 +1,116 @@
+**EXTENSION**
+
+# `PrimitiveSequenceType`
+
+## Methods
+### `dispatch(action:on:mode:fillOnError:)`
+
+```swift
+func dispatch<A: CompletableAction>(action: A.Type,
+                                    on dispatcher: Dispatcher,
+                                    mode: Dispatcher.DispatchMode.UI = .async,
+                                    fillOnError errorPayload: A.Payload? = nil)
+    -> Disposable where A.Payload == Self.Element
+```
+
+> Dispatches an given action from the result of the `Single` trait. This is only usable when the `Action` is a `CompletableAction`.
+> - Parameter action: The `CompletableAction` type to be dispatched.
+> - Parameter dispatcher: The `Dispatcher` object that will dispatch the action.
+> - Parameter mode: The `Dispatcher` dispatch mode, `.async` by default.
+> - Parameter fillOnError: The payload that will replace the action's payload in case of failure.
+
+#### Parameters
+
+| Name | Description |
+| ---- | ----------- |
+| action | The `CompletableAction` type to be dispatched. |
+| dispatcher | The `Dispatcher` object that will dispatch the action. |
+| mode | The `Dispatcher` dispatch mode, `.async` by default. |
+| fillOnError | The payload that will replace the action’s payload in case of failure. |
+
+### `dispatch(action:key:on:mode:fillOnError:)`
+
+```swift
+func dispatch<A: KeyedCompletableAction>(action: A.Type,
+                                         key: A.Key,
+                                         on dispatcher: Dispatcher,
+                                         mode: Dispatcher.DispatchMode.UI = .async,
+                                         fillOnError errorPayload: A.Payload? = nil)
+    -> Disposable where A.Payload == Self.Element
+```
+
+> Dispatches an given action from the result of the `Single` trait. This is only usable when the `Action` is a `CompletableAction`.
+> - Parameter action: The `CompletableAction` type to be dispatched.
+> - Parameter key: The key associated with the `Task` result.
+> - Parameter dispatcher: The `Dispatcher` object that will dispatch the action.
+> - Parameter mode: The `Dispatcher` dispatch mode, `.async` by default.
+> - Parameter fillOnError: The payload that will replace the action's payload in case of failure or `nil`.
+
+#### Parameters
+
+| Name | Description |
+| ---- | ----------- |
+| action | The `CompletableAction` type to be dispatched. |
+| key | The key associated with the `Task` result. |
+| dispatcher | The `Dispatcher` object that will dispatch the action. |
+| mode | The `Dispatcher` dispatch mode, `.async` by default. |
+| fillOnError | The payload that will replace the action’s payload in case of failure or `nil`. |
+
+### `action(_:fillOnError:)`
+
+```swift
+func action<A: CompletableAction>(_ action: A.Type,
+                                  fillOnError errorPayload: A.Payload? = nil)
+    -> Single<A> where A.Payload == Self.Element
+```
+
+> Builds a `CompletableAction` from a `Single`
+> - Parameter action: The `CompletableAction` type to be built.
+> - Parameter fillOnError: The payload that will replace the action's payload in case of failure or `nil`.
+> - Returns: A `Single` of the `CompletableAction` type declared by the action parameter.
+
+#### Parameters
+
+| Name | Description |
+| ---- | ----------- |
+| action | The `CompletableAction` type to be built. |
+| fillOnError | The payload that will replace the action’s payload in case of failure or `nil`. |
+
+### `dispatch(action:on:mode:)`
+
+```swift
+func dispatch<A: EmptyAction>(action: A.Type,
+                              on dispatcher: Dispatcher,
+                              mode: Dispatcher.DispatchMode.UI = .async)
+    -> Disposable
+```
+
+> Dispatches an given action from the result of the `Completable` trait. This is only usable when the `Action` is an `EmptyAction`.
+> - Parameter action: The `CompletableAction` type to be dispatched.
+> - Parameter dispatcher: The `Dispatcher` object that will dispatch the action.
+> - Parameter mode: The `Dispatcher` dispatch mode, `.async` by default.
+
+#### Parameters
+
+| Name | Description |
+| ---- | ----------- |
+| action | The `CompletableAction` type to be dispatched. |
+| dispatcher | The `Dispatcher` object that will dispatch the action. |
+| mode | The `Dispatcher` dispatch mode, `.async` by default. |
+
+### `action(_:)`
+
+```swift
+func action<A: EmptyAction>(_ action: A.Type)
+    -> Single<A>
+```
+
+> Builds an `EmptyAction` from a `Completable`
+> - Parameter action: The `EmptyAction` type to be built.
+> - Returns: A `Single` of the `EmptyAction` type declared by the action parameter.
+
+#### Parameters
+
+| Name | Description |
+| ---- | ----------- |
+| action | The `EmptyAction` type to be built. |


### PR DESCRIPTION
### PR's key points
With the latest refactor, `dispatch` and `action` methods from `PrimitiveSequenceType` `Single` and `Completable` traits were deleted by mistake. This PR adds the methods again to the package *MiniTasks*.
